### PR TITLE
Prep work for PyPI uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /dist/
 /test/test03PrintAll.out
+/.tox/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/MANIFEST
+/build/
+/dist/
+/test/test03PrintAll.out

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ install:
 sdist:
 	python setup.py sdist
 
+upload:
+	tox
+	python setup.py sdist upload
+
 check:
 	make -C test check
 

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,11 @@ install:
 sdist:
 	python setup.py sdist
 
-upload:
-	tox
+upload: distcheck
 	python setup.py sdist upload
+
+distcheck:
+	tox
 
 check:
 	make -C test check

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ srpm: sdist
 	cp python-augeas.spec dist
 	rpmbuild -bs --define "_srcrpmdir ."  --define '_sourcedir dist' dist/python-augeas.spec
 
-.PHONY: sdist install build clean check distclean srpm
+.PHONY: sdist install build clean check distclean srpm all upload distcheck

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-PREFIX := /usr
-
 VERSION = $(shell grep version setup.py|sed -e "s/^[^']*//;s/[',]//g;")
 
 all: build
 
 clean:
-	PREFIX=$(PREFIX) python setup.py clean
+	python setup.py clean
 	rm -f augeas.py* 
 
 distclean: clean
@@ -14,10 +12,10 @@ distclean: clean
 build: augeas.py
 
 install:
-	PREFIX=$(PREFIX) python setup.py install
+	python setup.py install
 
 sdist:
-	PREFIX=$(PREFIX) python setup.py sdist
+	python setup.py sdist
 
 check:
 	make -C test check

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup.py file for augeas
 """
 
 import os
-prefix = os.environ.get("prefix", "/usr")
 
 from distutils.core import setup
 

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,19 @@ import os
 
 from distutils.core import setup
 
-setup (name = 'python-augeas',
-       version = '0.4.1',
-       author      = "Harald Hoyer",
-       author_email = "augeas-devel@redhat.com",
-       description = """Python bindings for Augeas""",
-       py_modules = [ "augeas" ],
-       url = "http://augeas.net/",
-       )
+setup(
+    name='python-augeas',
+    version='0.4.1',
+    author="Harald Hoyer",
+    author_email="augeas-devel@redhat.com",
+    description="""Python bindings for Augeas""",
+    py_modules=[ "augeas" ],
+    url="https://github.com/hercules-team/python-augeas",
+    classifiers='''
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+    Operating System :: POSIX :: Linux
+    Intended Audience :: System Administrators
+    '''.strip().splitlines(),
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py33, py32, py27, py26
+
+[testenv]
+commands = /usr/bin/make check
+


### PR DESCRIPTION
This adds a rule to upload to PyPI (#2), which also runs the testsuite from packaged files (using tox).
