### PR TITLE
Added sanity  check to avoid an exception when the augeas object is already des...

### DIFF
--- a/augeas.py
+++ b/augeas.py
@@ -122,7 +122,8 @@ class Augeas(object):
         self.__handle = ctypes.c_void_p(self.__handle)
 
     def __del__(self):
-        self.close()
+        if Augeas:
+            self.close()
 
     def get(self, path):
         """Lookup the value associated with 'path'.


### PR DESCRIPTION
...troyed (Exception AttributeError: 'NoneType' object has no attribute '_libaugeas' in <bound method Augeas.__del__ of <augeas.Augeas object at 0xb6f764ac>> ignored)
