### PR TITLE
Bandaid for broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
   - sudo add-apt-repository -y ppa:raphink/augeas
   - sudo apt-get update
   - sudo apt-get install libaugeas-dev libxml2-dev
-  - C_INCLUDE_PATH=/usr/include/libxml2/ pip install .
+  - pip install .
 script: make check

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ clean:
 distclean: clean
 	rm -fr build dist MANIFEST
 
-build: PREFIX=$(PREFIX) python setup.py build
+build:
+	PREFIX=$(PREFIX) python setup.py build
 
 install:
 	PREFIX=$(PREFIX) python setup.py install

--- a/augeas/ffi.py
+++ b/augeas/ffi.py
@@ -5,7 +5,8 @@ ffi.set_source("augeas",
                """
                #include <augeas.h>
                """,
-               libraries=['augeas'])
+               libraries=['augeas'],
+               include_dirs=["/usr/include/libxml2"])
 
 ffi.cdef("""
 typedef struct augeas augeas;


### PR DESCRIPTION
This tries to address the broken build; it's not entirely right as the
include path for libxml should be taken from 'pkg-config --cflags
libxml-2.0' rather than be hardcoded.

This should address issues #21 and #20 