### PR TITLE
Fix error handling in get() and label()

### DIFF
--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -125,8 +125,8 @@ class Augeas(object):
 
         # Call the function and pass value by reference (char **)
         ret = lib.aug_get(self.__handle, enc(path), value)
-        if ret > 1:
-            raise ValueError("path specified had too many matches!")
+        if ret < 0:
+            raise ValueError("path specified had too many matches or is illegal!")
 
         return dec(ffi.string(value[0])) if value[0] != ffi.NULL else None
 

--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -146,8 +146,8 @@ class Augeas(object):
 
         # Call the function and pass value by reference (char **)
         ret = lib.aug_label(self.__handle, enc(path), label)
-        if ret > 1:
-            raise ValueError("path specified had too many matches!")
+        if ret < 0:
+            raise ValueError("path specified had too many matches or is illegal!")
 
         return dec(ffi.string(label[0])) if label[0] != ffi.NULL else None
 

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -34,10 +34,22 @@ def recurmatch(aug, path):
                     yield x
 
 class TestAugeas(unittest.TestCase):
-    def test01Get(self):
-        "test aug_get"
+    def test01aGetNone(self):
+        "test aug_get with non-existing path"
         a = augeas.Augeas(root=MYROOT)
-        self.failUnless(a.get("/wrong/path") == None)
+        self.failUnless(a.get("/wrong/path") is None)
+        del a
+
+    def test01bGetValue(self):
+        "test aug_get with existing path"
+        a = augeas.Augeas(root=MYROOT)
+        self.assertEqual(a.get("/files/etc/hosts/1/ipaddr"), "127.0.0.1")
+        del a
+
+    def test01cGetException(self):
+        "test aug_get with incorrect path"
+        a = augeas.Augeas(root=MYROOT)
+        self.assertRaises(ValueError, a.get, "/files//[1]/")
         del a
 
     def test02Match(self):

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -225,11 +225,18 @@ class TestAugeas(unittest.TestCase):
         excl = a.get("/augeas/load/Foo/excl")
         self.assertEqual(excl, "/tmp/baz")
 
-    def test14Label(self):
+    def test14aLabelOk(self):
+        """test aug_label with valid input"""
         a = augeas.Augeas(root=MYROOT)
 
         lbl = a.label("/augeas/version")
         self.assertEqual(lbl, "version")
+
+    def test14bLabelException(self):
+        """test aug_label with invalid input"""
+        a = augeas.Augeas(root=MYROOT)
+
+        self.assertRaises(ValueError, a.label, "/augeas/version/[1]/")
 
     def test15Copy(self):
         a = augeas.Augeas(root=MYROOT)


### PR DESCRIPTION
Errors reported by C library were not detected properly so ValueError was never raised.
