### PR TITLE
Allow running tests via `python test/test_augeas.py`

### DIFF
--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -4,14 +4,13 @@ import os
 import sys
 import unittest
 
-import augeas
-
 __mydir = os.path.dirname(sys.argv[0])
 if not os.path.isdir(__mydir):
     __mydir = os.getcwd()
 
 sys.path.insert(0, __mydir + "/..")
 
+import augeas
 
 MYROOT = __mydir + "/testroot"
 


### PR DESCRIPTION
The sys.path trick was introduced in ae4b815e5dcbb55a2cb72324a810872cf9d47332 but later got broken with a777e208f9250e0233757af23c35945a1e3df56d. This patch fixes it.
