### PR TITLE
Remove Python 3.2 from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
 - 2.6
 - 2.7
-- 3.2
 - 3.3
 - 3.4
 - 3.5


### PR DESCRIPTION
Python 3.2 is dead for quite some time now and it stopped working
because setuptools do not support it anymore.

This will remove false positives like in pull request #27.