### PR TITLE
 Refactor exceptions from Augeas errors 

### DIFF
--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -77,6 +77,12 @@ class Augeas(object):
     NO_MODL_AUTOLOAD = 1 << 6
     ENABLE_SPAN = 1 << 7
 
+    def _optffistring(self, cffistr):
+        if cffistr == ffi.NULL:
+            return None
+        else:
+            return dec(ffi.string(cffistr))
+
     def __init__(self, root=None, loadpath=None, flags=NONE):
         """Initialize the library.
 
@@ -125,7 +131,7 @@ class Augeas(object):
         if ret < 0:
             raise ValueError("path specified had too many matches or is illegal!")
 
-        return dec(ffi.string(value[0])) if value[0] != ffi.NULL else None
+        return self._optffistring(value[0])
 
     def label(self, path):
         """Lookup the label associated with 'path'.
@@ -146,7 +152,7 @@ class Augeas(object):
         if ret < 0:
             raise ValueError("path specified had too many matches or is illegal!")
 
-        return dec(ffi.string(label[0])) if label[0] != ffi.NULL else None
+        return self._optffistring(label[0])
 
     def set(self, path, value):
         """Set the value associated with 'path' to 'value'.
@@ -451,7 +457,7 @@ class Augeas(object):
                            span_start, span_end)
         if (ret < 0):
             raise ValueError("Error during span procedure")
-        fname = dec(ffi.string(filename[0])) if filename != ffi.NULL else None
+        fname = self._optffistring(filename[0])
         return (fname, int(label_start[0]), int(label_end[0]),
                 int(value_start[0]), int(value_end[0]),
                 int(span_start[0]), int(span_end[0]))

--- a/augeas/ffi.py
+++ b/augeas/ffi.py
@@ -35,6 +35,10 @@ int aug_text_retrieve(struct augeas *aug, const char *lens,
                       const char *node_out);
 int aug_transform(augeas *aug, const char *lens, const char *file, int excl);
 void aug_close(augeas *aug);
+int aug_error(augeas *aug);
+const char *aug_error_message(augeas *aug);
+const char *aug_error_minor_message(augeas *aug);
+const char *aug_error_details(augeas *aug);
 
 void free(void *);
 """)


### PR DESCRIPTION
Right now, when an augeas function returns an error, a generic Python exception (`IOError`, `RuntimeError`, or `ValueError`) is raised, with no way to even known the details of the failure.

Revamp a bit the system:
- create subclasses of exceptions based on the existing exception thrown, to maintain compatibility with existing users; these new exceptions have extra members 'error' (for the error code), 'msg' (for the error message), 'minor' (for the error explanations), and 'details' (for the details)
- add `AUG_*` constants for the all the Augeas errors
- simplify the own error strings to mention just the function, since the exception message will contain all the available details
- turn the `AUG_ENOMEM` error into a Python `MemoryError` exception, more Pythonic

Fixes #8.