### PR TITLE
Fix the majority of PEP8 issues

### DIFF
--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -30,15 +30,15 @@ format and the transformation into a tree.
 #
 # Author: Nathaniel McCallum <nathaniel@natemccallum.com>
 
+from sys import version_info as _pyver
+
+from augeas.ffi import ffi, lib
+
 __author__ = "Nathaniel McCallum <nathaniel@natemccallum.com>"
 __credits__ = """Jeff Schroeder <jeffschroeder@computer.org>
 Harald Hoyer <harald@redhat.com> - initial python bindings, packaging
 Nils Philippsen <nils@redhat.com>
 """
-from sys import version_info as _pyver
-
-from augeas.ffi import ffi, lib
-
 PY3 = _pyver >= (3,)
 AUGENC = 'utf8'
 

--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -187,7 +187,8 @@ class Augeas(object):
         loadpath = enc(loadpath) if loadpath else ffi.NULL
 
         # Create the Augeas object
-        self.__handle = ffi.gc(lib.aug_init(root, loadpath, flags), lambda x: self.close)
+        self.__handle = ffi.gc(lib.aug_init(root, loadpath, flags),
+                               lambda x: self.close)
         if not self.__handle:
             raise RuntimeError("Unable to create Augeas object!")
 
@@ -663,8 +664,8 @@ class Augeas(object):
 
         if name:
             import warnings
-            warnings.warn("name is now deprecated in this function", DeprecationWarning,
-                          stacklevel=2)
+            warnings.warn("name is now deprecated in this function",
+                          DeprecationWarning, stacklevel=2)
         if isinstance(incl, string_types):
             incl = [incl]
         if isinstance(excl, string_types):

--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -176,9 +176,9 @@ class Augeas(object):
         """
 
         # Sanity checks
-        if not isinstance(root, string_types) and root != None:
+        if not isinstance(root, string_types) and root is not None:
             raise TypeError("root MUST be a string or None!")
-        if not isinstance(loadpath, string_types) and loadpath != None:
+        if not isinstance(loadpath, string_types) and loadpath is not None:
             raise TypeError("loadpath MUST be a string or None!")
         if not isinstance(flags, int):
             raise TypeError("flag MUST be a flag!")
@@ -251,7 +251,7 @@ class Augeas(object):
         # Sanity checks
         if not isinstance(path, string_types):
             raise TypeError("path MUST be a string!")
-        if not isinstance(value, string_types) and type(value) != type(None):
+        if not isinstance(value, string_types) and value is not None:
             raise TypeError("value MUST be a string or None!")
         if not self.__handle:
             raise RuntimeError("The Augeas object has already been closed!")
@@ -273,9 +273,9 @@ class Augeas(object):
         # Sanity checks
         if type(base) != str:
             raise TypeError("base MUST be a string!")
-        if type(sub) != str and sub != None:
+        if type(sub) != str and sub is not None:
             raise TypeError("sub MUST be a string or None!")
-        if type(value) != str and value != None:
+        if type(value) != str and value is not None:
             raise TypeError("value MUST be a string or None!")
         if not self.__handle:
             raise RuntimeError("The Augeas object has already been closed!")
@@ -355,7 +355,7 @@ class Augeas(object):
         # Sanity checks
         if type(name) != str:
             raise TypeError("name MUST be a string!")
-        if type(expr) != str and expr != None:
+        if type(expr) != str and expr is not None:
             raise TypeError("expr MUST be a string or None!")
         if not self.__handle:
             raise RuntimeError("The Augeas object has already been closed!")

--- a/augeas/ffi.py
+++ b/augeas/ffi.py
@@ -15,7 +15,8 @@ int aug_defnode(augeas *aug, const char *name, const char *expr,
 int aug_get(const augeas *aug, const char *path, const char **value);
 int aug_label(const augeas *aug, const char *path, const char **label);
 int aug_set(augeas *aug, const char *path, const char *value);
-int aug_setm(augeas *aug, const char *base, const char *sub, const char *value);
+int aug_setm(augeas *aug, const char *base, const char *sub,
+             const char *value);
 int aug_span(augeas *aug, const char *path, char **filename,
         unsigned int *label_start, unsigned int *label_end,
         unsigned int *value_start, unsigned int *value_end,

--- a/setup.py
+++ b/setup.py
@@ -13,29 +13,29 @@ prefix = os.environ.get("prefix", "/usr")
 name = 'python-augeas'
 version = '1.0.3'
 
-setup (name = name,
-       version = version,
-       author      = "Harald Hoyer",
-       author_email = "augeas-devel@redhat.com",
-       description = """Python bindings for Augeas""",
-       packages=find_packages(exclude=('test')),
-       setup_requires=["cffi>=1.0.0"],
-       cffi_modules=["augeas/ffi.py:ffi"],
-       install_requires=["cffi>=1.0.0"],
-       url = "http://augeas.net/",
-       classifiers=[
-           "Programming Language :: Python :: 2.7",
-           "Programming Language :: Python :: 3.4",
-           "Programming Language :: Python :: 3.5",
-           "Programming Language :: Python :: 3.6",
-           "Programming Language :: Python :: Implementation :: CPython",
-           "Programming Language :: Python :: Implementation :: PyPy",
-       ],
-       command_options = {
-           'build_sphinx': {
-               'project': ('setup.py', name),
-               'version': ('setup.py', version),
-               'release': ('setup.py', version),
-           }
-       },
-       )
+setup(name=name,
+      version=version,
+      author="Harald Hoyer",
+      author_email="augeas-devel@redhat.com",
+      description="""Python bindings for Augeas""",
+      packages=find_packages(exclude=('test')),
+      setup_requires=["cffi>=1.0.0"],
+      cffi_modules=["augeas/ffi.py:ffi"],
+      install_requires=["cffi>=1.0.0"],
+      url="http://augeas.net/",
+      classifiers=[
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: Implementation :: CPython",
+          "Programming Language :: Python :: Implementation :: PyPy",
+      ],
+      command_options={
+          'build_sphinx': {
+              'project': ('setup.py', name),
+              'version': ('setup.py', version),
+              'release': ('setup.py', version),
+          }
+      },
+      )

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -119,16 +119,16 @@ class TestAugeas(unittest.TestCase):
 
     def test08Span(self):
         "test span"
-        data = [ {"expr": "/files/etc/hosts/1/ipaddr", "f": "hosts",
-                  "ls": 0, "le": 0, "vs": 104, "ve": 113, "ss": 104, "se": 113},
-                 {"expr": "/files/etc/hosts/1", "f": "hosts",
-                  "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 104, "se": 155},
-                 {"expr": "/files/etc/hosts/*[last()]", "f": "hosts",
-                  "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 155, "se": 202},
-                 {"expr": "/files/etc/hosts/#comment[2]", "f": "hosts",
-                  "ls": 0, "le": 0, "vs": 58, "ve": 103, "ss": 56, "se": 104},
-                 {"expr": "/files/etc/hosts", "f": "hosts",
-                  "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 0, "se":202 },
+        data = [{"expr": "/files/etc/hosts/1/ipaddr", "f": "hosts",
+                 "ls": 0, "le": 0, "vs": 104, "ve": 113, "ss": 104, "se": 113},
+                {"expr": "/files/etc/hosts/1", "f": "hosts",
+                 "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 104, "se": 155},
+                {"expr": "/files/etc/hosts/*[last()]", "f": "hosts",
+                 "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 155, "se": 202},
+                {"expr": "/files/etc/hosts/#comment[2]", "f": "hosts",
+                 "ls": 0, "le": 0, "vs": 58, "ve": 103, "ss": 56, "se": 104},
+                {"expr": "/files/etc/hosts", "f": "hosts",
+                 "ls": 0, "le": 0, "vs": 0, "ve": 0, "ss": 0, "se": 202},
                 ]
         a = augeas.Augeas(root=MYROOT, flags=augeas.Augeas.ENABLE_SPAN)
         for d in data:

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -14,6 +14,7 @@ import augeas
 
 MYROOT = __mydir + "/testroot"
 
+
 def recurmatch(aug, path):
     if path:
         if path != "/":
@@ -31,6 +32,7 @@ def recurmatch(aug, path):
             for i in aug.match(path + "/*"):
                 for x in recurmatch(aug, i):
                     yield x
+
 
 class TestAugeas(unittest.TestCase):
     def test01aGetNone(self):


### PR DESCRIPTION
Fix the majority of the PEP8 issues on all the `.py` files in the sources; some of the issues in `test_augeas.py` will be fixed by the work on the test, #40.

After this + #40, the only PEP8 issue left is:
>  test/test_augeas.py:13:1: E402 module level import not at top of file

which seems a valid use case, so not changing it for now (and it's just a test anyway).