### PR TITLE
Add load_file, source, srun to the API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: python
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
 - 3.7
 - 3.8
-- pypy
-notifications:
-  email:
-  - raphael.pinson@camptocamp.com
+- pypy2
+- pypy3
+notifications: {}
+dist: bionic
 install:
-- sudo add-apt-repository -y ppa:raphink/augeas
 - sudo apt-get update
 - sudo apt-get install libaugeas-dev
+- wget http://mirrors.kernel.org/ubuntu/pool/universe/a/augeas/libaugeas0_1.12.0-1build1_amd64.deb
+- sudo dpkg -i libaugeas0_1.12.0-1build1_amd64.deb
 - pip install .
 script: make check
 deploy:

--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -641,6 +641,46 @@ class Augeas(object):
         if ret != 0:
             self._raise_error(AugeasRuntimeError, "Augeas.load() failed")
 
+    def load_file(self, filename):
+        # Sanity checks
+        if not isinstance(filename, string_types):
+            raise TypeError("filename MUST be a string!")
+        if not self.__handle:
+            raise RuntimeError("The Augeas object has already been closed!")
+
+        ret = lib.aug_load_file(self.__handle, enc(filename))
+        if ret != 0:
+            raise RuntimeError("aug_load_file() failed!")
+
+    def source(self, path):
+        # Sanity checks
+        if not isinstance(path, string_types):
+            raise TypeError("path MUST be a string!")
+        if not self.__handle:
+            raise RuntimeError("The Augeas object has already been closed!")
+
+        # Create the char * value
+        value = ffi.new("char*[]", 1)
+
+        ret = lib.aug_source(self.__handle, enc(path), value)
+        if ret != 0:
+            raise RuntimeError("aug_source() failed!")
+
+        return self._optffistring(value[0])
+
+    def srun(self, out, command):
+        # Sanity checks
+        if not hasattr(out, 'write'):
+            raise TypeError("out MUST be a file!")
+        if not isinstance(command, string_types):
+            raise TypeError("path MUST be a string!")
+        if not self.__handle:
+            raise RuntimeError("The Augeas object has already been closed!")
+
+        ret = lib.aug_srun(self.__handle, out, enc(command))
+        if ret < 0:
+            raise RuntimeError("aug_srun() failed! (%d)" % ret)
+
     def clear_transforms(self):
         """
         Clear all transforms beneath :samp:`/augeas/load`. If :func:`load` is

--- a/augeas/ffi.py
+++ b/augeas/ffi.py
@@ -35,6 +35,10 @@ int aug_text_retrieve(struct augeas *aug, const char *lens,
                       const char *node_in, const char *path,
                       const char *node_out);
 int aug_transform(augeas *aug, const char *lens, const char *file, int excl);
+int aug_source(const augeas *aug, const char *path, char **file_path);
+int aug_srun(augeas *aug, FILE *out, const char *text);
+int aug_load_file(augeas *aug, const char *file);
+
 void aug_close(augeas *aug);
 int aug_error(augeas *aug);
 const char *aug_error_message(augeas *aug);

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -242,6 +242,27 @@ class TestAugeas(unittest.TestCase):
         self.assertTrue(matches)
         self.assertEqual(a.get(copy_path), a.get(orig_path))
 
+    def test16LoadFile(self):
+        a = augeas.Augeas(root=MYROOT, flags=augeas.Augeas.NO_LOAD)
+        a.load_file('/etc/hosts')
+        canonical = a.get('/files/etc/hosts/*[ipaddr = \'::1\']/canonical')
+        self.assertEqual(canonical,'localhost.localdomain')
+
+    def test17Source(self):
+        a = augeas.Augeas(root=MYROOT)
+        source_file = a.source('/files/etc/hosts/1/ipaddr')
+        self.assertEqual(source_file,'/files/etc/hosts')
+
+    def test18Srun(self):
+        a = augeas.Augeas(root=MYROOT)
+        output_srun = open('test18Srun.out', 'w')
+        a.srun(output_srun,'count /files/etc/hosts//ipaddr')
+        output_srun.close()
+        output_srun = open('test18Srun.out', 'r')
+        srun_text = output_srun.read()
+        output_srun.close()
+        self.assertEqual(srun_text.strip(),'2 matches')
+
     def testClose(self):
         a = augeas.Augeas(root=MYROOT)
         a.close()


### PR DESCRIPTION
Added the following API calls:

load_file()
   eg load_file('/etc/hosts')
source()
   eg source('/files/etc/hosts/1/ipaddr')
srun()
   eg srun(sys.stdout,'print /augeas//error')