### PR TITLE
Use CFFI in out-of-line API mode

### DIFF
--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -32,7 +32,7 @@ format and the transformation into a tree.
 
 from sys import version_info as _pyver
 
-from augeas.ffi import ffi, lib
+from _augeas import ffi, lib
 
 __author__ = "Nathaniel McCallum <nathaniel@natemccallum.com>"
 __credits__ = """Jeff Schroeder <jeffschroeder@computer.org>

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name=name,
       setup_requires=["cffi>=1.0.0"],
       cffi_modules=["augeas/ffi.py:ffi"],
       install_requires=["cffi>=1.0.0"],
+      zip_safe=False,
       url="http://augeas.net/",
       classifiers=[
           "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Currently, ffi.py is called during setup to generate augeas.py; this file would normally be used for out-of-line ABI mode. ffi.py is also imported at run-time, instead of the generated augeas.py, and used in in-line ABI mode.

This changes usage of CFFI to out-of-line API mode (CFFI's "main mode of usage"): ffi.py is called during setup to generate _augeas.abi3.so (a C extension module); this generated module is imported at run-time.

With this change, the headers/development files for augeas (i.e. libaugeas-dev on Debian, augeas-devel on Fedora, etc.) and the C compiler are required for build/setup. (These were not necessary previously.)

Closes https://github.com/hercules-team/python-augeas/issues/48.