### PR TITLE
Add preview, ns_attr, ns_label, ns_value, ns_count, ns_path to the API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
 notifications: {}
 dist: focal
 install:
-- sudo apt-get update
-- sudo apt-get install libaugeas-dev
+- git clone  --depth 1 https://github.com/hercules-team/augeas.git libaugeas
+- bash -c 'cd libaugeas ; ./autogen.sh ; ./configure --prefix=/usr; make; sudo make install'
 - pip install .
 script: make check
 deploy:

--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -681,6 +681,96 @@ class Augeas(object):
         if ret < 0:
             raise RuntimeError("aug_srun() failed! (%d)" % ret)
 
+    def preview(self, path):
+        # Sanity checks
+        if not isinstance(path, string_types):
+            raise TypeError("path MUST be a string!")
+        if not self.__handle:
+            raise RuntimeError("The Augeas object has already been closed!")
+
+        # Create the char * value
+        out = ffi.new("char*[]", 1)
+
+        ret = lib.aug_preview(self.__handle, enc(path), out)
+        if ret < 0:
+            raise RuntimeError("aug_preview() failed! (%d)" % ret)
+        return self._optffistring(out[0])
+
+    def ns_attr(self, name, index):
+        # Sanity checks
+        if not isinstance(name, string_types):
+            raise TypeError("name MUST be a string!")
+        if not isinstance(index, int):
+            raise TypeError("index MUST be an integer!")
+        value = ffi.new("char*[]", 1)
+        label = ffi.new("char*[]", 1)
+        file_path  = ffi.new("char*[]", 1)
+
+        ret = lib.aug_ns_attr(self.__handle, enc(name), index, value, label, file_path)
+        if ret < 0:
+            raise RuntimeError("aug_ns_attr() failed! (%d)" % ret)
+
+        return (self._optffistring(value[0]), self._optffistring(label[0]), self._optffistring(file_path[0]) )
+
+    def ns_label(self, name, index):
+        # Sanity checks
+        if not isinstance(name, string_types):
+            raise TypeError("name MUST be a string!")
+        if not isinstance(index, int):
+            raise TypeError("index MUST be an integer!")
+
+        # Create the char * value
+        label = ffi.new("char*[]", 1)
+        labelindex = ffi.new("int*", 1)
+
+        ret = lib.aug_ns_label(self.__handle, enc(name), index, label, labelindex)
+
+        if ret < 0:
+            raise RuntimeError("aug_label() failed! (%d)" % ret)
+
+        return (self._optffistring(label[0]), labelindex[0] )
+
+    def ns_value(self, name, index):
+        # Sanity checks
+        if not isinstance(name, string_types):
+            raise TypeError("name MUST be a string!")
+        if not isinstance(index, int):
+            raise TypeError("index MUST be an integer!")
+
+        # Create the char * value
+        value = ffi.new("char*[]", 1)
+
+        ret = lib.aug_ns_value(self.__handle, enc(name), index, value)
+        if ret < 0:
+            raise RuntimeError("aug_ns_value() failed! (%d)" % ret)
+        return self._optffistring(value[0])
+
+    def ns_count(self, name):
+        # Sanity checks
+        if not isinstance(name, string_types):
+            raise TypeError("name MUST be a string!")
+        ret = lib.aug_ns_count(self.__handle, enc(name))
+        if ret < 0:
+            raise RuntimeError("aug_ns_count() failed! (%d)" % ret)
+        return ret
+
+
+    def ns_path(self, name, index):
+        # Sanity checks
+        if not isinstance(name, string_types):
+            raise TypeError("name MUST be a string!")
+        if not isinstance(index, int):
+            raise TypeError("index MUST be an integer!")
+
+        # Create the char * value
+        path = ffi.new("char*[]", 1)
+
+        ret = lib.aug_ns_path(self.__handle, enc(name), index, path)
+        if ret < 0:
+            raise RuntimeError("aug_ns_path() failed! (%d)" % ret)
+        return self._optffistring(path[0])
+
+
     def clear_transforms(self):
         """
         Clear all transforms beneath :samp:`/augeas/load`. If :func:`load` is

--- a/augeas/ffi.py
+++ b/augeas/ffi.py
@@ -38,6 +38,17 @@ int aug_transform(augeas *aug, const char *lens, const char *file, int excl);
 int aug_source(const augeas *aug, const char *path, char **file_path);
 int aug_srun(augeas *aug, FILE *out, const char *text);
 int aug_load_file(augeas *aug, const char *file);
+int aug_preview(augeas *aug, const char *path, char **out);
+int aug_ns_attr(const augeas* aug, const char *var, int i,
+                const char **value, const char **label, char **file_path);
+int aug_ns_label(const augeas *aug, const char *var, int i,
+                 const char **label, int *index);
+int aug_ns_value(const augeas *aug, const char *var, int i,
+                 const char **value);
+int aug_ns_count(const augeas *aug, const char *var);
+int aug_ns_path(const augeas *aug, const char *var, int i, char **path);
+
+
 
 void aug_close(augeas *aug);
 int aug_error(augeas *aug);

--- a/test/test_augeas.py
+++ b/test/test_augeas.py
@@ -263,6 +263,35 @@ class TestAugeas(unittest.TestCase):
         output_srun.close()
         self.assertEqual(srun_text.strip(),'2 matches')
 
+    def test20Preview(self):
+        "test preview"
+        a = augeas.Augeas(root=MYROOT)
+        preview = a.preview("/files/etc/hosts/1/ipaddr")
+        etc_hosts = open(MYROOT+'/etc/hosts', 'r')
+        etc_hosts_text = etc_hosts.read()
+        etc_hosts.close()
+        self.assertEqual(preview, etc_hosts_text)
+        del a
+
+    def test21Ns_attr(self):
+        "test ns_attr, ns_label, ns_value, ns_count, ns_path"
+        a = augeas.Augeas(root=MYROOT)
+        a.defvar("hosts", "/files/etc/hosts/*")
+        a.defvar("hosts_1", "/files/etc/hosts/1/*")
+        (value, label, file_path )  = a.ns_attr("hosts_1",2)
+        self.assertEqual(label, "alias")
+        self.assertEqual(value, "localhost")
+        self.assertEqual(file_path, "/files/etc/hosts")
+        value = a.ns_value("hosts_1",1)
+        self.assertEqual(value, "localhost.localdomain")
+        ( label, index) = a.ns_label("hosts_1",1)
+        self.assertEqual(label, "canonical")
+        self.assertEqual(index, 0)
+        count = a.ns_count("hosts")
+        self.assertEqual(count, 4)
+        path = a.ns_path("hosts",2)
+        self.assertEqual(path, "/files/etc/hosts/1")
+
     def testClose(self):
         a = augeas.Augeas(root=MYROOT)
         a.close()


### PR DESCRIPTION
This Pull Requests add the following augeas API calls:

preview()
ns_attr()
ns_label()
ns_value()
ns_count()
ns_path()

Note that for this PR, the api calls: ns_attr() ns_label() return python tuples.

Please let me know if this is unsuitable in some way.
