### PR TITLE
correctly close Augeas instance when ffi handle is garbage collected

### DIFF
--- a/augeas/__init__.py
+++ b/augeas/__init__.py
@@ -188,7 +188,7 @@ class Augeas(object):
 
         # Create the Augeas object
         self.__handle = ffi.gc(lib.aug_init(root, loadpath, flags),
-                               lambda x: self.close)
+                               lambda x: self.close())
         if not self.__handle:
             raise RuntimeError("Unable to create Augeas object!")
 


### PR DESCRIPTION
Previously the lambda would only return a **reference** to `self.close` but would not actually ***execute*** the `.close()` method. This bug was introduced in commit bd62d096.